### PR TITLE
Add support for OCaml 4.10

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,0 +1,2 @@
+(lang dune 1.0)
+(name bytearray)

--- a/src/bytearray_stubs.c
+++ b/src/bytearray_stubs.c
@@ -37,17 +37,8 @@ CAMLprim value ml_unmarshal_from_bigarray(value b, value ofs)
 CAMLprim value ml_blit_string_to_bigarray
 (value s, value i, value a, value j, value l)
 {
-  char *src = String_val(s) + Int_val(i);
+  const char *src = String_val(s) + Int_val(i);
   char *dest = Array_data(Bigarray_val(a), j);
-  memcpy(dest, src, Long_val(l));
-  return Val_unit;
-}
-
-CAMLprim value ml_blit_bigarray_to_string
-(value a, value i, value s, value j, value l)
-{
-  char *src = Array_data(Bigarray_val(a), i);
-  char *dest = String_val(s) + Long_val(j);
   memcpy(dest, src, Long_val(l));
   return Val_unit;
 }


### PR DESCRIPTION
Currently your package fails with OCaml 4.10 or any OCaml version with `-force-safe-string` enabled, with the following error message:
```
#=== ERROR while compiling bytearray.1.0.0 ====================================#
# context              2.0.5 | linux/x86_64 | ocaml-variants.4.10.0+trunk | file:///home/opam/opam-repository
# path                 ~/.opam/4.10.0+trunk/.opam-switch/build/bytearray.1.0.0
# command              ~/.opam/4.10.0+trunk/bin/dune build -p bytearray -j 71
# exit-code            1
# env-file             ~/.opam/log/bytearray-6-d80009.env
# output-file          ~/.opam/log/bytearray-6-d80009.out
### output ###
# /home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/mlvalues.h:265:23: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
# [...]
# bytearray_stubs.c:40:15: note: in expansion of macro 'String_val'
#    40 |   char *src = String_val(s) + Int_val(i);
#       |               ^~~~~~~~~~
# bytearray_stubs.c: In function 'ml_blit_bigarray_to_string':
# /home/opam/.opam/4.10.0+trunk/lib/ocaml/caml/mlvalues.h:265:23: error: initialization discards 'const' qualifier from pointer target type [-Werror=discarded-qualifiers]
#   265 | #define String_val(x) ((const char *) Bp_val(x))
#       |                       ^
# bytearray_stubs.c:50:16: note: in expansion of macro 'String_val'
#    50 |   char *dest = String_val(s) + Long_val(j);
#       |                ^~~~~~~~~~
# cc1: all warnings being treated as errors
```
This PR fixes the issue. I removed the `ml_blit_bigarray_to_string` function because it was unused and it does not make sense post 4.06.